### PR TITLE
fix: Remove stdin.setEncoding('utf8') to prevent stdio framing errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stabgan/openrouter-mcp-multimodal",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stabgan/openrouter-mcp-multimodal",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,6 @@ if (process.argv.length > 2) {
 
 // Attempt to parse JSON from stdin to check for MCP server parameters
 if (!mcpOptions?.apiKey) {
-  process.stdin.setEncoding('utf8');
   process.stdin.once('data', (data) => {
     try {
       const firstMessage = JSON.parse(data.toString());


### PR DESCRIPTION
The MCP TypeScript SDK’s stdio transport reads binary chunks (Buffer/Uint8Array) and operates on them (e.g., via .subarray()). Forcing stdin into UTF-8 string mode caused Node to emit strings, leading to repeated “TypeError: this._buffer.subarray is not a function” in the logs.

This commit removes the setEncoding call so stdin remains binary. If text parsing is needed, it should decode locally from Buffer (e.g., buffer.toString('utf8')).

Resolves #3