### PR TITLE
fix(fetch): send User-Agent so CDN-fronted hosts don't return HTTP 400

### DIFF
--- a/src/tool-handlers/fetch-utils.ts
+++ b/src/tool-handlers/fetch-utils.ts
@@ -299,7 +299,19 @@ export async function fetchHttpResource(
     const t = setTimeout(() => controller.abort(), opts.timeoutMs);
     let res: Response;
     try {
-      res = await fetch(target, { redirect: 'manual', signal: controller.signal });
+      res = await fetch(target, {
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: {
+          // Some CDNs/WAFs (notably Wikimedia/Varnish) reject requests
+          // without a User-Agent with HTTP 400. Identify ourselves so
+          // analyze_image / analyze_audio / analyze_video work against
+          // those origins. See https://github.com/stabgan/openrouter-mcp-multimodal/issues/13
+          'User-Agent':
+            'openrouter-mcp-multimodal/3.0.0 (+https://github.com/stabgan/openrouter-mcp-multimodal)',
+          Accept: 'image/*, audio/*, video/*, */*;q=0.8',
+        },
+      });
     } finally {
       clearTimeout(t);
     }


### PR DESCRIPTION
## Summary

- `fetchHttpResource` now sends an explicit `User-Agent` and `Accept` header on its `fetch()` call so requests through CDNs that screen on UA (most visibly Wikimedia/Varnish) succeed instead of being rejected with `HTTP 400`.
- Closes #13.

## Why this matters

`analyze_image`, `analyze_audio`, and `analyze_video` all funnel URL inputs through `fetchHttpResource` → `fetch()`. With Node's default fetch, no `User-Agent` is sent, and Wikimedia (and a handful of Cloudflare-fronted origins) return `HTTP 400` to those requests. The error bubbles up to the MCP caller as a bare `HTTP 400` that *looks* like an OpenRouter / model failure but is actually the image host rejecting the package's fetch.

The diagnostic that points at the local fetcher rather than the model: `chat_completion` with an inline `image_url` content part on the *same* URL + *same* model succeeds, because OpenRouter fetches the asset server-side with a real UA. `curl -I` reproduces the same UA-screening behavior end-to-end (`HTTP/2 400` with no UA, `200` with `Mozilla/5.0`).

## Repro before the fix

```ts
await client.callTool('analyze_image', {
  image_path: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/640px-Cat03.jpg',
  question: 'What is in this image?',
  model: 'google/gemini-2.5-flash',
});
// → { error: 'HTTP 400' }
```

After the fix the same call returns the expected description.

## Test plan

- [x] Local rebuild + `analyze_image` against the Wikimedia URL above returns the model's description (verified manually with `google/gemini-2.5-flash`)
- [ ] Existing test suite passes (please run in CI; I haven't run the package's tests locally)
- [ ] Spot-check `analyze_audio` and `analyze_video` against UA-screening hosts — same code path, should benefit identically

## Notes

- The UA string embeds `3.0.0` to match `package.json`. If you'd rather pull this dynamically (e.g. from `package.json` or a build constant) I'm happy to follow up — kept it static here to keep the diff minimal and avoid module-resolution surprises in the dist build.
- I considered hoisting the headers into a shared constant but there's only one `fetch()` call site in this file, so a literal felt clearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)