### PR TITLE
generate_image: support reference images and modalities passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@stabgan/openrouter-mcp-multimodal` are recorded here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`generate_image` reference images.** New optional `input_images: string[]` field on `generate_image`. Each entry is a local file path, an `http(s)://` URL, or a `data:image/...;base64,...` URL. When provided, the user message becomes a multimodal `ChatCompletionContentPart[]`: a text preamble + one `image_url` block per ref, in input order. Enables character/style consistency, image-to-image, and iterative refinement on chat-image models (Gemini Nano Banana, `openai/gpt-5.4-image-2`).
+- **`generate_image` modalities override.** New optional `modalities: string[]` field on `generate_image`. Defaults to the `["image","text"]` value v3.1.0 hardcodes; provide e.g. `["text"]` to suppress image output for inspection / captioning.
+- **`OPENROUTER_INPUT_DIR` env var.** Sandbox root for `input_images` file paths. Falls back to `OPENROUTER_OUTPUT_DIR`, then `cwd`. Honors `OPENROUTER_ALLOW_UNSAFE_PATHS=1` for the legacy bypass, matching `save_path` semantics.
+- **`generate-image.test.ts`.** 18 unit tests covering `mimeFromExt`, `resolveInputImage` (data/http passthrough, file → base64, traversal rejection, symlink-aware sandbox, env-var fallback), and `buildUserContent` (text vs multimodal branches, preamble, order preservation).
+
 ## [3.1.1] — 2026-05-03
 
 ### Added

--- a/src/__tests__/generate-image.test.ts
+++ b/src/__tests__/generate-image.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import {
+  resolveInputImage,
+  buildUserContent,
+  mimeFromExt,
+} from '../tool-handlers/generate-image.js';
+import { UnsafeOutputPathError } from '../tool-handlers/path-safety.js';
+
+describe('mimeFromExt', () => {
+  it('maps known image extensions', () => {
+    expect(mimeFromExt('.png')).toBe('image/png');
+    expect(mimeFromExt('png')).toBe('image/png');
+    expect(mimeFromExt('.PNG')).toBe('image/png');
+    expect(mimeFromExt('.jpg')).toBe('image/jpeg');
+    expect(mimeFromExt('.jpeg')).toBe('image/jpeg');
+    expect(mimeFromExt('.webp')).toBe('image/webp');
+    expect(mimeFromExt('.gif')).toBe('image/gif');
+  });
+
+  it('returns null for unknown extensions', () => {
+    expect(mimeFromExt('.tiff')).toBeNull();
+    expect(mimeFromExt('')).toBeNull();
+  });
+});
+
+describe('resolveInputImage', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(tmpdir(), 'mcp-input-image-'));
+    vi.stubEnv('OPENROUTER_INPUT_DIR', root);
+    vi.stubEnv('OPENROUTER_OUTPUT_DIR', '');
+    vi.stubEnv('OPENROUTER_ALLOW_UNSAFE_PATHS', '');
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('passes data: URLs through unchanged', async () => {
+    const url = 'data:image/png;base64,iVBORw0KGgo=';
+    expect(await resolveInputImage(url)).toBe(url);
+  });
+
+  it('passes http(s) URLs through unchanged', async () => {
+    expect(await resolveInputImage('https://example.com/a.png')).toBe(
+      'https://example.com/a.png',
+    );
+    expect(await resolveInputImage('http://example.com/a.jpg')).toBe(
+      'http://example.com/a.jpg',
+    );
+  });
+
+  it('reads a relative file under the root and inlines as base64 data URL', async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(root, 'ref.png'), bytes);
+
+    const url = await resolveInputImage('ref.png');
+    expect(url).toBe(`data:image/png;base64,${bytes.toString('base64')}`);
+  });
+
+  it('detects mime from extension (.jpeg → image/jpeg)', async () => {
+    const bytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+    await fs.writeFile(path.join(root, 'photo.jpeg'), bytes);
+
+    const url = await resolveInputImage('photo.jpeg');
+    expect(url.startsWith('data:image/jpeg;base64,')).toBe(true);
+  });
+
+  it('falls back to image/png for unknown extensions', async () => {
+    await fs.writeFile(path.join(root, 'mystery.bin'), Buffer.from([0x00]));
+    const url = await resolveInputImage('mystery.bin');
+    expect(url.startsWith('data:image/png;base64,')).toBe(true);
+  });
+
+  it('accepts absolute paths that land inside the root', async () => {
+    const bytes = Buffer.from([1, 2, 3]);
+    const abs = path.join(root, 'inside.webp');
+    await fs.writeFile(abs, bytes);
+
+    const url = await resolveInputImage(abs);
+    expect(url).toBe(`data:image/webp;base64,${bytes.toString('base64')}`);
+  });
+
+  it('rejects traversal attempts that escape the root', async () => {
+    await expect(resolveInputImage('../escape.png')).rejects.toBeInstanceOf(
+      UnsafeOutputPathError,
+    );
+  });
+
+  it('rejects absolute paths outside the root', async () => {
+    await expect(resolveInputImage('/etc/passwd')).rejects.toBeInstanceOf(
+      UnsafeOutputPathError,
+    );
+  });
+
+  it('bypasses the sandbox when OPENROUTER_ALLOW_UNSAFE_PATHS=1', async () => {
+    vi.stubEnv('OPENROUTER_ALLOW_UNSAFE_PATHS', '1');
+
+    const outside = path.join(tmpdir(), `mcp-unsafe-input-${Date.now()}.png`);
+    const bytes = Buffer.from([42]);
+    await fs.writeFile(outside, bytes);
+
+    const url = await resolveInputImage(outside);
+    expect(url).toBe(`data:image/png;base64,${bytes.toString('base64')}`);
+
+    await fs.rm(outside, { force: true });
+  });
+
+  it('rejects empty entries', async () => {
+    await expect(resolveInputImage('')).rejects.toThrow(/empty/);
+    await expect(resolveInputImage('   ')).rejects.toThrow(/empty/);
+  });
+
+  it('falls back to OPENROUTER_OUTPUT_DIR when INPUT_DIR is unset', async () => {
+    vi.stubEnv('OPENROUTER_INPUT_DIR', '');
+    vi.stubEnv('OPENROUTER_OUTPUT_DIR', root);
+
+    const bytes = Buffer.from([0xab]);
+    await fs.writeFile(path.join(root, 'fallback.gif'), bytes);
+
+    const url = await resolveInputImage('fallback.gif');
+    expect(url).toBe(`data:image/gif;base64,${bytes.toString('base64')}`);
+  });
+});
+
+describe('buildUserContent', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(tmpdir(), 'mcp-build-content-'));
+    vi.stubEnv('OPENROUTER_INPUT_DIR', root);
+    vi.stubEnv('OPENROUTER_OUTPUT_DIR', '');
+    vi.stubEnv('OPENROUTER_ALLOW_UNSAFE_PATHS', '');
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns a plain string when no input_images are provided', async () => {
+    const out = await buildUserContent('a sunset', undefined);
+    expect(out).toBe('Generate an image: a sunset');
+  });
+
+  it('returns a plain string for an empty input_images array', async () => {
+    const out = await buildUserContent('a sunset', []);
+    expect(out).toBe('Generate an image: a sunset');
+  });
+
+  it('builds multimodal content with text preamble and one image_url per ref', async () => {
+    const out = await buildUserContent('khalid in the majlis', [
+      'data:image/png;base64,AAA=',
+      'https://example.com/lantern.png',
+    ]);
+
+    expect(Array.isArray(out)).toBe(true);
+    const parts = out as Array<Record<string, unknown>>;
+    expect(parts).toHaveLength(3);
+
+    expect(parts[0]).toMatchObject({ type: 'text' });
+    expect(String((parts[0] as { text: string }).text)).toContain('khalid in the majlis');
+    expect(String((parts[0] as { text: string }).text)).toContain('reference image');
+
+    expect(parts[1]).toMatchObject({
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,AAA=', detail: 'high' },
+    });
+    expect(parts[2]).toMatchObject({
+      type: 'image_url',
+      image_url: { url: 'https://example.com/lantern.png', detail: 'high' },
+    });
+  });
+
+  it('preserves the order of input_images', async () => {
+    const out = await buildUserContent('scene', [
+      'https://example.com/a.png',
+      'https://example.com/b.png',
+      'https://example.com/c.png',
+    ]);
+
+    const urls = (out as Array<Record<string, unknown>>)
+      .filter((p) => p.type === 'image_url')
+      .map((p) => (p.image_url as { url: string }).url);
+    expect(urls).toEqual([
+      'https://example.com/a.png',
+      'https://example.com/b.png',
+      'https://example.com/c.png',
+    ]);
+  });
+
+  it('inlines local file refs as base64', async () => {
+    const bytes = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+    await fs.writeFile(path.join(root, 'face.png'), bytes);
+
+    const out = await buildUserContent('scene', ['face.png']);
+    const parts = out as Array<Record<string, unknown>>;
+    expect((parts[1].image_url as { url: string }).url).toBe(
+      `data:image/png;base64,${bytes.toString('base64')}`,
+    );
+  });
+});

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -213,7 +213,11 @@ export class ToolHandlers {
         },
         {
           name: 'generate_image',
-          description: 'Generate an image from a text prompt',
+          description:
+            'Generate an image from a text prompt. Optionally conditioned on one or more ' +
+            'reference images (file paths, http(s) URLs, or data URLs) for character / style ' +
+            'consistency. Sends `modalities: ["image","text"]` by default; override via the ' +
+            '`modalities` field if needed.',
           annotations: {
             readOnlyHint: false,
             destructiveHint: false,
@@ -261,6 +265,23 @@ export class ToolHandlers {
                 type: 'string',
                 description:
                   'Optional path to save the image. Routed through the OPENROUTER_OUTPUT_DIR sandbox.',
+              },
+              input_images: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Optional reference images for visual consistency. Each entry may be a ' +
+                  'local file path (sandboxed to OPENROUTER_INPUT_DIR / OPENROUTER_OUTPUT_DIR / ' +
+                  'cwd), an http(s) URL, or a `data:image/...;base64,...` URL. Inlined as ' +
+                  'multimodal user content in the order given.',
+              },
+              modalities: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Override the default `modalities: ["image","text"]` sent to OpenRouter. ' +
+                  'Most callers should leave this unset. Provide e.g. ["text"] to suppress ' +
+                  'image output for inspection / captioning.',
               },
             },
             required: ['prompt'],

--- a/src/tool-handlers/generate-image.ts
+++ b/src/tool-handlers/generate-image.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import path from 'node:path';
 import OpenAI from 'openai';
 import type { ChatCompletion } from 'openai/resources/chat/completions.js';
 import { resolveSafeOutputPath, UnsafeOutputPathError } from './path-safety.js';
@@ -13,7 +14,7 @@ export interface GenerateImageToolRequest {
   /**
    * Output aspect ratio. Passed through as `image_config.aspect_ratio`.
    * Supported by OpenRouter image models (e.g. `1:1`, `16:9`, `9:16`,
-   * `4:3`, `3:4`, `21:9`). Model-dependent — unsupported values fall back
+   * `4:3`, `3:4`, `21:9`). Model-dependent. Unsupported values fall back
    * to the model's default. See
    * https://openrouter.ai/docs/guides/overview/multimodal/image-generation
    */
@@ -32,6 +33,27 @@ export interface GenerateImageToolRequest {
    * for the image payload + any caption.
    */
   max_tokens?: number;
+  /**
+   * Optional reference images. Each entry is one of:
+   *   - a `data:image/...;base64,...` URL,
+   *   - an `http(s)://` URL (OpenRouter fetches it),
+   *   - a local file path (sandboxed to `OPENROUTER_INPUT_DIR` /
+   *     `OPENROUTER_OUTPUT_DIR` / cwd, read + base64-encoded by the server).
+   *
+   * When provided, the user message becomes multimodal: a text prompt
+   * plus one `image_url` block per reference, in array order. Enables
+   * character / style consistency and image-to-image refinement on
+   * chat-image models that accept image inputs (Gemini Nano Banana,
+   * `openai/gpt-5.4-image-2`).
+   */
+  input_images?: string[];
+  /**
+   * Override the default `modalities: ["image","text"]` sent to
+   * OpenRouter. Most callers should leave this unset. Provide e.g.
+   * `["text"]` to suppress image output for inspection / captioning,
+   * or other shapes for future model variants.
+   */
+  modalities?: string[];
 }
 
 const DEFAULT_MODEL = 'google/gemini-2.5-flash-image';
@@ -62,8 +84,16 @@ export async function handleGenerateImage(
   request: { params: { arguments: GenerateImageToolRequest } },
   openai: OpenAI,
 ) {
-  const { prompt, model, save_path, aspect_ratio, image_size, max_tokens } =
-    request.params.arguments ?? { prompt: '' };
+  const {
+    prompt,
+    model,
+    save_path,
+    aspect_ratio,
+    image_size,
+    max_tokens,
+    input_images,
+    modalities,
+  } = request.params.arguments ?? { prompt: '' };
 
   if (!prompt?.trim()) {
     return toolError(ErrorCode.INVALID_INPUT, 'prompt is required.');
@@ -97,9 +127,24 @@ export async function handleGenerateImage(
     }
   }
 
-  // Assemble the request body. OpenRouter's image-generation guide requires
-  //   - `modalities: ["image", "text"]` so multimodal models (like Gemini)
-  //     know to emit an image, not just text;
+  // Build the user message. With no `input_images`, this is the original
+  // string content; with refs, it becomes a multimodal
+  // ChatCompletionContentPart[] (text preamble + one image_url per ref).
+  let content: string | OpenAI.Chat.Completions.ChatCompletionContentPart[];
+  try {
+    content = await buildUserContent(prompt, input_images);
+  } catch (err) {
+    if (err instanceof UnsafeOutputPathError) {
+      return toolErrorFrom(ErrorCode.UNSAFE_PATH, err);
+    }
+    return toolErrorFrom(ErrorCode.INVALID_INPUT, err, 'input_images');
+  }
+
+  // Assemble the request body. OpenRouter's image-generation guide
+  // requires:
+  //   - `modalities: ["image", "text"]` so multimodal models (like
+  //     Gemini) know to emit an image, not just text. Caller can
+  //     override via the `modalities` field.
   //   - `image_config.{aspect_ratio, image_size}` for shape control.
   // The OpenAI SDK doesn't type these fields, but passes unknown members
   // through to the server, so we attach them via a typed cast.
@@ -109,8 +154,8 @@ export async function handleGenerateImage(
 
   const body: Record<string, unknown> = {
     model: model || DEFAULT_MODEL,
-    messages: [{ role: 'user', content: `Generate an image: ${prompt}` }],
-    modalities: ['image', 'text'],
+    messages: [{ role: 'user', content }],
+    modalities: modalities && modalities.length ? modalities : ['image', 'text'],
   };
   if (Object.keys(imageConfig).length > 0) body.image_config = imageConfig;
   if (typeof max_tokens === 'number' && max_tokens > 0) body.max_tokens = max_tokens;
@@ -137,8 +182,9 @@ export async function handleGenerateImage(
   if (!base64) {
     // Model talked but did not emit an image. Surface this as a distinct
     // condition so callers don't treat chatter as a successful image.
-    const content = message.content;
-    const text = typeof content === 'string' ? content : JSON.stringify(content);
+    const messageContent = message.content;
+    const text =
+      typeof messageContent === 'string' ? messageContent : JSON.stringify(messageContent);
     return toolError(
       ErrorCode.UPSTREAM_REFUSED,
       `Model returned no image. Text response: ${text.slice(0, 300)}`,
@@ -193,6 +239,109 @@ export async function handleGenerateImage(
         : {}),
     },
   };
+}
+
+/**
+ * Resolve a caller-supplied input image into a URL the chat-completions
+ * API accepts. Local file paths are sandboxed to the workspace root
+ * (`OPENROUTER_INPUT_DIR` or `OPENROUTER_OUTPUT_DIR` or cwd) and inlined
+ * as base64 data URLs.
+ */
+export async function resolveInputImage(ref: string): Promise<string> {
+  const trimmed = ref.trim();
+  if (!trimmed) throw new Error('empty input_images entry');
+
+  if (trimmed.startsWith('data:')) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+
+  const root = path.resolve(
+    process.env.OPENROUTER_INPUT_DIR || process.env.OPENROUTER_OUTPUT_DIR || process.cwd(),
+  );
+  const unsafe =
+    process.env.OPENROUTER_ALLOW_UNSAFE_PATHS === '1' ||
+    process.env.OPENROUTER_ALLOW_UNSAFE_PATHS?.toLowerCase() === 'true';
+
+  // Realpath the root first so absolute paths the caller already gave in
+  // canonical form (e.g. /private/var/...) and paths we resolve against
+  // the root (which may go through /var/... symlinks on macOS) live in
+  // the same namespace for the prefix check below.
+  const rootReal = await fs.realpath(root).catch(() => root);
+  const abs = path.isAbsolute(trimmed)
+    ? path.resolve(trimmed)
+    : path.resolve(rootReal, trimmed);
+
+  if (!unsafe) {
+    const withSep = rootReal.endsWith(path.sep) ? rootReal : rootReal + path.sep;
+
+    // Prefer realpath for the prefix check so callers can pass paths
+    // through symlinks (e.g. macOS `/var/...` → `/private/var/...`)
+    // without us rejecting them. If the file doesn't exist yet, fall
+    // back to a textual check on the resolved path so traversal
+    // (`../escape.png`) is still rejected with the right error type
+    // instead of leaking an ENOENT to the caller.
+    let canonical: string;
+    try {
+      canonical = await fs.realpath(abs);
+    } catch {
+      canonical = abs;
+    }
+
+    if (!(canonical === rootReal || canonical.startsWith(withSep))) {
+      throw new UnsafeOutputPathError(
+        `input_images entry resolves outside workspace root (${rootReal}): ${ref}`,
+      );
+    }
+  }
+
+  const buf = await fs.readFile(abs);
+  const mime = mimeFromExt(path.extname(abs)) || 'image/png';
+  return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+export function mimeFromExt(ext: string): string | null {
+  const e = ext.toLowerCase().replace(/^\./, '');
+  switch (e) {
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'webp':
+      return 'image/webp';
+    case 'gif':
+      return 'image/gif';
+    default:
+      return null;
+  }
+}
+
+export async function buildUserContent(
+  prompt: string,
+  inputImages?: string[],
+): Promise<string | OpenAI.Chat.Completions.ChatCompletionContentPart[]> {
+  if (!inputImages?.length) {
+    return `Generate an image: ${prompt}`;
+  }
+
+  const parts: OpenAI.Chat.Completions.ChatCompletionContentPart[] = [
+    {
+      type: 'text',
+      text:
+        `Generate an image based on this prompt, using the following reference image(s) ` +
+        `for visual consistency. Match the appearance, identity, and style of the references ` +
+        `closely; do not alter them.\n\nPrompt: ${prompt}`,
+    },
+  ];
+
+  for (const ref of inputImages) {
+    const url = await resolveInputImage(ref);
+    parts.push({
+      type: 'image_url',
+      image_url: { url, detail: 'high' },
+    });
+  }
+
+  return parts;
 }
 
 function extractBase64(message: Record<string, unknown>): { data: string; mime: string } | null {


### PR DESCRIPTION
Closes #15.

## What

Two additive fields on `generate_image`, no breaking changes:

- `input_images: string[]`. Each entry is a local file path, an `http(s)://` URL, or a `data:image/...;base64,...` URL. When non-empty, the user message becomes a multimodal `ChatCompletionContentPart[]`: a text preamble + one `image_url` block per ref, in input order.
- `modalities: string[]`. Spread into `chat.completions.create` when non-empty. Required for chat-image models that gate image output behind `modalities: ["image","text"]` (e.g. `openai/gpt-5.4-image-2`).

## Why

Issue #15 covers it. Short version: chat-image models that support image inputs (Gemini Nano Banana, `openai/gpt-5.4-image-2`) currently can't be used for character/style consistency or image-to-image because `generate_image` hardcodes the message to a string. `chat_completion` doesn't fill the gap either; it discards `message.images`.

## Sandbox

File paths are routed through a new `OPENROUTER_INPUT_DIR` env var, falling back to `OPENROUTER_OUTPUT_DIR`, then `cwd`. Honors the existing `OPENROUTER_ALLOW_UNSAFE_PATHS=1` bypass. The prefix check uses realpath of the root (macOS `/var/...` to `/private/var/...`) and falls back to a textual check when the file doesn't exist, so traversal (`../escape.png`) returns `UNSAFE_PATH` instead of leaking ENOENT.

`data:` and `http(s)://` entries pass through unchanged (OpenRouter fetches the URL itself, no local I/O).

## Tests

New `src/__tests__/generate-image.test.ts`: 18 cases covering `mimeFromExt`, `resolveInputImage` (data/http passthrough, file to base64, traversal rejection, symlink-aware sandbox, env-var fallback), and `buildUserContent` (text vs multimodal branches, preamble content, order preservation).

`npm test` is 181 / 181 green.

## Naming

Used `input_images` to match the OpenAI chat-completions input vocabulary. `generate_video` already exposes a `reference_images` field with very similar semantics; happy to rename for cross-tool consistency if you prefer. One `git mv`-grade change.

## Out of scope

- `chat_completion` still discards `message.images`. Surfacing them there would let callers do image gen via the chat tool too, but it's a separate change with its own schema impact (the tool currently returns only `text` content).
- `generate-image.test.ts` covers helpers, not the full handler. The handler's network path matches the existing audio/video tests' style (no SDK mocking), and the live E2E harness already exercises it.